### PR TITLE
added ability to read environment variables

### DIFF
--- a/twitterwipe.py
+++ b/twitterwipe.py
@@ -1,4 +1,4 @@
-import os, sys
+import os
 import tweepy
 import json
 import yaml

--- a/twitterwipe.py
+++ b/twitterwipe.py
@@ -1,4 +1,4 @@
-import os
+import os, sys
 import tweepy
 import json
 import yaml
@@ -107,9 +107,18 @@ def delete_favorites(api, ts):
     return
 
 
-def get_api():
-    with open(full_path + '/keys.json', 'r') as f:
-        d = json.load(f)
+def get_api( ):
+
+    try:
+        # get keys from os environment variables if they exist
+        d = { 'consumer_key' : os.environ['CONSUMER_KEY'],
+              'consumer_secret' : os.environ['CONSUMER_SECRET'],
+              'app_key' : os.environ['APP_KEY'],
+              'app_secret' :os.environ['APP_SECRET'] }
+    except KeyError:
+        # environment variables are not found, so try the json file instead
+        with open(full_path + '/keys.json', 'r') as f:
+            d = json.load(f)
 
     auth = tweepy.OAuthHandler(d['consumer_key'], d['consumer_secret'])
     auth.set_access_token(d['app_key'], d['app_secret'])


### PR DESCRIPTION
Added the ability to try and read the api and consumer keys from environment variables first. If the variables are not present, then read from the json file. 

I'm planning to wrap this into a serverless function and don't want to bundle the keys in with the code. Instead, they can be imported as environment variables. 