### PR TITLE
Twitter wipe improved to support json imports from Twitter archive

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,4 +4,8 @@ log.log
 config.yaml
 tweet.js
 like.js
+docker-compose.yml
+Dockerfile
 .env
+log.log
+.gitignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,6 @@ FROM python:3.8.4-slim
 
 WORKDIR '/twitterwipe'
 
-ENV COMMAND=''
-ENV ARGS=''
-ENV APP_KEY=''
-ENV APP_SECRET=''
-ENV CONSUMER_KEY=''
-ENV CONSUMER_SECRET=''
-ENV TZ=''
-
 COPY . .
 
 RUN ["pip", "install", "-r", "requirements.txt"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.8.4-slim
+
+WORKDIR '/twitterwipe'
+
+ENV COMMAND=''
+ENV ARGS=''
+ENV APP_KEY=''
+ENV APP_SECRET=''
+ENV CONSUMER_KEY=''
+ENV CONSUMER_SECRET=''
+ENV TZ=''
+
+COPY . .
+
+RUN ["pip", "install", "-r", "requirements.txt"]
+
+ENTRYPOINT python3 twitterwipe.py $COMMAND $ARGS
+
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3.6'
+
+services:
+  twitterwipe:
+    image: dantebarba/twitterwipe:latest
+    container_name: twitterwipe
+    environment:
+      APP_KEY: ${APP_KEY}
+      APP_SECRET: ${APP_SECRET}
+      CONSUMER_KEY: ${CONSUMER_KEY}
+      CONSUMER_SECRET: ${CONSUMER_SECRET}
+      COMMAND: ${COMMAND}
+      ARGS: ${ARGS}
+      TZ: 'America/Argentina/Buenos_Aires'
+    volumes:
+      - ./keys.json:/twitterwipe/keys.json
+      - ./like.js:/twitterwipe/like.js
+      - ./tweet.js:/twitterwipe/tweet.js
+      - ./config.yaml:/twitterwipe/config.yaml
+      - ./log.log:/twitterwipe/log.log

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.6'
 
 services:
   twitterwipe:
-    image: dantebarba/twitterwipe:latest
+    build: .
     container_name: twitterwipe
     environment:
       APP_KEY: ${APP_KEY}
@@ -11,7 +11,7 @@ services:
       CONSUMER_SECRET: ${CONSUMER_SECRET}
       COMMAND: ${COMMAND}
       ARGS: ${ARGS}
-      TZ: 'America/Argentina/Buenos_Aires'
+      TZ: ${TZ}
     volumes:
       - ./keys.json:/twitterwipe/keys.json
       - ./like.js:/twitterwipe/like.js

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,6 @@ requests==2.22.0
 requests-oauthlib==1.3.0
 six==1.14.0
 tweepy==3.8.0
+urllib3==1.25.7
 pandas==1.0.5
 click==7.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,5 @@ requests==2.22.0
 requests-oauthlib==1.3.0
 six==1.14.0
 tweepy==3.8.0
-urllib3==1.25.7
+pandas==1.0.5
+click==7.1.2

--- a/twitterwipe.py
+++ b/twitterwipe.py
@@ -4,25 +4,33 @@ import json
 import yaml
 import logging
 import concurrent.futures
+import pandas
+import click
+from dateutil import parser
 from datetime import timedelta, datetime
 
 full_path = os.path.dirname(os.path.realpath(__file__))
 
 logging.basicConfig(filename=full_path + '/log.log', level=logging.INFO,
-        format='%(asctime)s %(message)s')
+                    format='%(asctime)s %(message)s')
 
 logger = logging.getLogger(__name__)
+
 
 def main():
     logger.info('starting twitterwipe')
 
-    with open(full_path + '/config.yaml', 'r') as yamlfile:
-        config = yaml.load(yamlfile, Loader=yaml.FullLoader)
+    config = open_config()
 
     delete_timestamps = get_delete_timestamps(config)
     purge_activity(delete_timestamps)
 
     logger.info('done')
+
+
+def open_config():
+    with open(full_path + '/config.yaml', 'r') as yamlfile:
+        return yaml.load(yamlfile, Loader=yaml.FullLoader)
 
 
 def get_delete_timestamps(config):
@@ -53,6 +61,42 @@ def purge_activity(delete_timestamps):
         e.submit(delete_favorites, api, delete_timestamps[0])
 
 
+def find_tweet_by_id(api, tweet_id):
+    try:
+        return api.get_status(tweet_id)
+    except Exception as e:
+        logger.error("failed to find {}".format(tweet_id), exc_info=True)
+        return None
+
+
+def delete_tweet_by_id(api, tweet_id):
+    try:
+        api.destroy_status(tweet_id)
+        return 1
+    except Exception as e:
+        logger.error("failed to delete {}".format(tweet_id), exc_info=True)
+        return 0
+
+
+def delete_favorite_by_id(api, tweet_id):
+    try:
+        api.destroy_favorite(tweet_id)
+        return 1
+    except:
+        logger.error('failed to delete favorite'.format(
+            tweet_id), exc_info=True)
+        return 0
+
+
+def delete_retweet_by_id(api, tweet_id):
+    try:
+        api.unretweet(tweet_id)
+        return 1
+    except:
+        logger.error('failed to unretweet {}'.format(tweet_id), exc_info=True)
+        return 0
+
+
 def delete_tweets(api, ts):
     logger.info('deleting tweets before {}'.format(str(ts)))
 
@@ -60,11 +104,7 @@ def delete_tweets(api, ts):
 
     for status in tweepy.Cursor(api.user_timeline).items():
         if status.created_at < ts:
-            try:
-                api.destroy_status(status.id)
-                count += 1
-            except Exception as e:
-                logger.error("failed to delete {}".format(status.id), exc_info=True)
+            count += delete_tweet_by_id(api, status.id)
 
     logger.info('{} tweets deleted'.format(count))
 
@@ -78,13 +118,9 @@ def delete_retweets(api, ts):
 
     for status in tweepy.Cursor(api.user_timeline).items():
         if status.created_at < ts:
-            try:
-                api.unretweet(status.id)
-                count+=1
-            except:
-                logger.error('failed to unretweet {}'.format(status.id),exc_info=True)
-    logger.info('{} retweets deleted'.format(count))
+            count += delete_retweet_by_id(api, status.id)
 
+    logger.info('{} retweets deleted'.format(count))
 
     return
 
@@ -96,25 +132,21 @@ def delete_favorites(api, ts):
 
     for status in tweepy.Cursor(api.favorites).items():
         if status.created_at < ts:
-            try:
-                api.destroy_favorite(status.id)
-                count+=1
-            except:
-                logger.error('failed to delete favorite'.format(status.id), exc_info=True)
+            count += delete_favorite_by_id(api, status.id)
 
     logger.info('{} favorites deleted'.format(count))
 
     return
 
 
-def get_api( ):
+def get_api():
 
     try:
         # get keys from os environment variables if they exist
-        d = { 'consumer_key' : os.environ['CONSUMER_KEY'],
-              'consumer_secret' : os.environ['CONSUMER_SECRET'],
-              'app_key' : os.environ['APP_KEY'],
-              'app_secret' :os.environ['APP_SECRET'] }
+        d = {'consumer_key': os.environ['CONSUMER_KEY'],
+             'consumer_secret': os.environ['CONSUMER_SECRET'],
+             'app_key': os.environ['APP_KEY'],
+             'app_secret': os.environ['APP_SECRET']}
     except KeyError:
         # environment variables are not found, so try the json file instead
         with open(full_path + '/keys.json', 'r') as f:
@@ -126,5 +158,169 @@ def get_api( ):
     return tweepy.API(auth, wait_on_rate_limit=True, wait_on_rate_limit_notify=True)
 
 
-if __name__ == '__main__':
+def get_csv_ids(csv):
+
+    if not csv:
+        raise FileNotFoundError("No csv has been loaded")
+
+    return pandas.read_csv(csv, lineterminator='\n')[["tweet.id", "tweet.created_at"]]
+
+
+def test_string_in_file(json_file, string):
+    if (string in json_file.read()):
+        raise Exception("Please delete the " + string +
+                        " token in the json and then try again")
+
+
+def check_fixed_json(json_file):
+    test_string_in_file(json_file, "window.YTD.like.part")
+    test_string_in_file(json_file, "window.YTD.tweet.part")
+    json_file.seek(0)
+
+
+def get_js_ids(js):
+
+    if not js:
+        raise FileNotFoundError("No json has been loaded")
+
+    with open(js, 'r', encoding='utf8') as json_file:
+        check_fixed_json(json_file)
+        return pandas.read_json(json_file)
+
+
+def delete_tweets_by_id(api, tweets_id, ts):
+
+    logger.info('deleting tweets by id before {}'.format(str(ts)))
+
+    count = 0
+
+    for index, status in tweets_id.iterrows():
+        if parser.parse(status["tweet.created_at"]).replace(tzinfo=None) < ts.replace(tzinfo=None):
+            count += delete_tweet_by_id(api, status["tweet.id"])
+
+    logger.info('{} tweets by id deleted '.format(count))
+
+
+def delete_tweets_by_id_js(api, tweets_id, ts):
+
+    logger.info('deleting tweets by id before {}'.format(str(ts)))
+
+    count = 0
+
+    for tweet in tweets_id:
+        if parser.parse(tweet["timestamp"]).replace(tzinfo=None) < ts.replace(tzinfo=None):
+            count += delete_tweet_by_id(api, tweet["id"])
+
+    logger.info('{} tweets by id deleted '.format(count))
+
+
+def delete_likes_by_id(api, tweets_id, ts):
+    logger.info('deleting likes by id before {}'.format(str(ts)))
+
+    count = 0
+
+    for tweet in tweets_id:
+        status = find_tweet_by_id(api, tweet["id"])
+        if status and status.created_at.replace(tzinfo=None) < ts.replace(tzinfo=None):
+            count += delete_favorite_by_id(api, tweet["id"])
+
+    logger.info('{} likes by id deleted '.format(count))
+
+
+@click.group()
+def actions():
+    """
+        Welcome to twitterwipe. Please use --help on each
+        available command.
+    """
+    pass
+
+
+@actions.command()
+def wipe_using_api():
+    """ 
+        This command will wipe all your likes, retweets and tweets
+        from your account preceding a certain number of days. Please keep
+        in mind that due to Twitter API limitations, 
+        this command will only retrive up to 3200 tweets.
+    """
     main()
+
+
+@actions.command()
+@click.option('--csv', help='CSV file location', required='true')
+def delete_tweets_from_csv(csv):
+    """
+        This command allows you to delete all your tweets preceding a certain number
+        of days taking as input a comma-separated CSV file. This CSV file should have
+        two mandatory columns:
+            - tweet.id
+            - tweet.created_at
+    """
+    tweets_id = get_csv_ids(csv)
+
+    config = open_config()
+
+    timestamps = get_delete_timestamps(config)
+
+    api = get_api()
+
+    delete_tweets_by_id(api, tweets_id, timestamps[2])
+
+    logger.info('done from csv')
+
+
+@actions.command()
+@click.option('--json', help='tweet.js location', required='true')
+def delete_tweets_from_js(json):
+    """
+        This command allows you to wipe all your tweets preceding a certain number
+        of days. It takes as input the tweet.js file. You can get this file by asking for your data
+        from Twitter.
+    """
+    tweets_id = get_js_ids(json)
+
+    config = open_config()
+
+    timestamps = get_delete_timestamps(config)
+
+    api = get_api()
+
+    tweets = map(lambda status: {
+                 "id": status[1].tweet["id"], "timestamp": status[1].tweet["created_at"]}, tweets_id.iterrows())
+
+    delete_tweets_by_id_js(api, tweets, timestamps[2])
+
+    logger.info('done from json')
+
+
+@actions.command()
+@click.option('--json', help='like.js location', required='true')
+def delete_likes_from_js(json):
+    """  
+        This command allows you to wipe all your likes preceding a certain number
+        of days. It takes as input the like.js file. You can get this file by asking for your data
+        from Twitter.
+    """
+    tweets_id = get_js_ids(json)
+
+    config = open_config()
+
+    timestamps = get_delete_timestamps(config)
+
+    api = get_api()
+
+    tweets = map(lambda status: {
+                 "id": status[1].like["tweetId"], "timestamp": None}, tweets_id.iterrows())
+
+    delete_likes_by_id(api, tweets, timestamps[2])
+
+    logger.info('done from json')
+
+
+if __name__ == '__main__':
+    actions().add_command(wipe_using_api)
+    actions().add_command(delete_tweets_from_csv)
+    actions().add_command(delete_tweets_from_js)
+    actions().add_command(delete_likes_from_js)
+    actions()


### PR DESCRIPTION
As you may already know, twitter has decided to limit tweet retrieval
to 3200 tweets.

To circumvent this limitation, I've implemented the possibility to import the JSON file provided by Twitter archive, to import all the tweets and likes ids, thus allowing to delete every single one by id. Furthermore, it's seems that we are in luck, because there is no limitation on how many tweets you can process by id. This allows you to delete all your tweets in one pass.

The application has been tested with an account with over 15k tweets.
It deleted not just the tweets but retweets and likes/fav

Plus, a CLI has been added to facilitate configuration. You can access the help
menu using --help

And just to add a cherry on top, it has been fully dockerized, and it includes
a docker-compose.yml example.

TLDR;

- Delete tweets by id using json
- Delete favs by id using json
- CLI, using "click" library
- Dockerized, with docker-compose as example.

Roadmap?

- Maybe CI? Travis?
- Improve logging. When API Cursor or Auth fails, there is no log information.
- Improve logging, give time-remaining estimates or log every n-th processed
entry, to keep track of what the
script is doing
- Improve summary.